### PR TITLE
4.3.3-05

### DIFF
--- a/docker/chi-arches/chiarches/arches/app/models/models.py
+++ b/docker/chi-arches/chiarches/arches/app/models/models.py
@@ -705,7 +705,7 @@ def auto_delete_file_on_delete(sender, instance, **kwargs):
     """Deletes file from filesystem
     when corresponding `FileValue` object is deleted.
     """
-    if instance.value.path:
+    if instance.value.name:
         try:
             if os.path.isfile(instance.value.path):
                 os.remove(instance.value.path)


### PR DESCRIPTION
Fixed error - Couldn't delete thesauri/collection.

File "/web_root/ENV/local/lib/python2.7/site-packages/django/db/models/fields/files.py", line 65, in path
return self.storage.path(self.name)
File "/web_root/ENV/local/lib/python2.7/site-packages/django/core/files/storage.py", line 111, in path
raise NotImplementedError("This backend doesn't support absolute paths.")
NotImplementedError: This backend doesn't support absolute paths.